### PR TITLE
feat: ドメイン層の最重要テストコードを追加

### DIFF
--- a/src/internal/domain/entity/post_test.go
+++ b/src/internal/domain/entity/post_test.go
@@ -1,0 +1,341 @@
+package entity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MizukiShigi/cms-go/internal/domain/valueobject"
+)
+
+func TestNewPost(t *testing.T) {
+	userID := valueobject.NewUserID()
+	title, _ := valueobject.NewPostTitle("テストタイトル")
+	content, _ := valueobject.NewPostContent("テストコンテンツ")
+
+	tests := []struct {
+		name    string
+		title   valueobject.PostTitle
+		content valueobject.PostContent
+		userID  valueobject.UserID
+		status  valueobject.PostStatus
+		wantErr bool
+	}{
+		{
+			name:    "正常ケース: 下書き投稿作成",
+			title:   title,
+			content: content,
+			userID:  userID,
+			status:  valueobject.StatusDraft,
+			wantErr: false,
+		},
+		{
+			name:    "正常ケース: 公開投稿作成",
+			title:   title,
+			content: content,
+			userID:  userID,
+			status:  valueobject.StatusPublished,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			post, err := NewPost(tt.title, tt.content, tt.userID, tt.status)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("エラーが期待されましたが、エラーが発生しませんでした")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("予期しないエラー: %v", err)
+				return
+			}
+
+			if post == nil {
+				t.Error("投稿がnilです")
+				return
+			}
+
+			// フィールドの検証
+			if !post.Title.Equals(tt.title) {
+				t.Errorf("Title = %v, want %v", post.Title, tt.title)
+			}
+
+			if !post.Content.Equals(tt.content) {
+				t.Errorf("Content = %v, want %v", post.Content, tt.content)
+			}
+
+			if !post.UserID.Equals(tt.userID) {
+				t.Errorf("UserID = %v, want %v", post.UserID, tt.userID)
+			}
+
+			if !post.Status.Equals(tt.status) {
+				t.Errorf("Status = %v, want %v", post.Status, tt.status)
+			}
+
+			// IDが生成されていることを確認
+			if post.ID.String() == "" {
+				t.Error("投稿IDが生成されていません")
+			}
+
+			// タイムスタンプが設定されていることを確認
+			if post.CreatedAt.IsZero() {
+				t.Error("CreatedAtが設定されていません")
+			}
+
+			if post.UpdatedAt.IsZero() {
+				t.Error("UpdatedAtが設定されていません")
+			}
+
+			// 公開投稿の場合FirstPublishedAtが設定されていることを確認
+			if tt.status == valueobject.StatusPublished {
+				if post.FirstPublishedAt == nil || post.FirstPublishedAt.IsZero() {
+					t.Error("公開投稿のFirstPublishedAtが設定されていません")
+				}
+			}
+
+			// ContentUpdatedAtが設定されていることを確認
+			if post.ContentUpdatedAt == nil || post.ContentUpdatedAt.IsZero() {
+				t.Error("ContentUpdatedAtが設定されていません")
+			}
+		})
+	}
+}
+
+func TestPost_AddTag(t *testing.T) {
+	userID := valueobject.NewUserID()
+	title, _ := valueobject.NewPostTitle("テストタイトル")
+	content, _ := valueobject.NewPostContent("テストコンテンツ")
+	post, _ := NewPost(title, content, userID, valueobject.StatusDraft)
+
+	tag1, _ := valueobject.NewTagName("golang")
+	tag2, _ := valueobject.NewTagName("testing")
+
+	tests := []struct {
+		name        string
+		tag         valueobject.TagName
+		setup       func()
+		wantErr     bool
+		expectedErr string
+	}{
+		{
+			name:    "正常ケース: タグ追加",
+			tag:     tag1,
+			setup:   func() {},
+			wantErr: false,
+		},
+		{
+			name:    "正常ケース: 2番目のタグ追加",
+			tag:     tag2,
+			setup:   func() {},
+			wantErr: false,
+		},
+		{
+			name:        "異常ケース: 重複タグ追加",
+			tag:         tag1,
+			setup:       func() {},
+			wantErr:     true,
+			expectedErr: "Tag already exists",
+		},
+		{
+			name: "異常ケース: 最大タグ数超過",
+			tag:  tag1,
+			setup: func() {
+				// 投稿を新規作成して10個のタグを追加
+				post, _ = NewPost(title, content, userID, valueobject.StatusDraft)
+				for i := 0; i < 10; i++ {
+					tagName, _ := valueobject.NewTagName("tag" + string(rune('0'+i)))
+					post.AddTag(tagName)
+				}
+			},
+			wantErr:     true,
+			expectedErr: "Maximum number of tags reached",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setup()
+			err := post.AddTag(tt.tag)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("エラーが期待されましたが、エラーが発生しませんでした")
+					return
+				}
+				if err.Error() != tt.expectedErr {
+					t.Errorf("期待されたエラーメッセージ = %v, 実際のエラーメッセージ = %v", tt.expectedErr, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("予期しないエラー: %v", err)
+			}
+		})
+	}
+}
+
+func TestPost_SetStatus(t *testing.T) {
+	userID := valueobject.NewUserID()
+	title, _ := valueobject.NewPostTitle("テストタイトル")
+	content, _ := valueobject.NewPostContent("テストコンテンツ")
+
+	tests := []struct {
+		name         string
+		initialStatus valueobject.PostStatus
+		targetStatus  valueobject.PostStatus
+		wantErr      bool
+		expectedErr  string
+	}{
+		{
+			name:         "正常ケース: 下書きから公開",
+			initialStatus: valueobject.StatusDraft,
+			targetStatus:  valueobject.StatusPublished,
+			wantErr:      false,
+		},
+		{
+			name:         "正常ケース: 下書きから削除",
+			initialStatus: valueobject.StatusDraft,
+			targetStatus:  valueobject.StatusDeleted,
+			wantErr:      false,
+		},
+		{
+			name:         "正常ケース: 公開から非公開",
+			initialStatus: valueobject.StatusPublished,
+			targetStatus:  valueobject.StatusPrivate,
+			wantErr:      false,
+		},
+		{
+			name:         "正常ケース: 非公開から公開",
+			initialStatus: valueobject.StatusPrivate,
+			targetStatus:  valueobject.StatusPublished,
+			wantErr:      false,
+		},
+		{
+			name:         "正常ケース: 非公開から削除",
+			initialStatus: valueobject.StatusPrivate,
+			targetStatus:  valueobject.StatusDeleted,
+			wantErr:      false,
+		},
+		{
+			name:         "異常ケース: 公開から削除（不正な遷移）",
+			initialStatus: valueobject.StatusPublished,
+			targetStatus:  valueobject.StatusDeleted,
+			wantErr:      true,
+			expectedErr:  "Only draft and private posts can be deleted",
+		},
+		{
+			name:         "異常ケース: 削除から公開（不正な遷移）",
+			initialStatus: valueobject.StatusDeleted,
+			targetStatus:  valueobject.StatusPublished,
+			wantErr:      true,
+			expectedErr:  "Only draft and private posts can be published",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			post, _ := NewPost(title, content, userID, tt.initialStatus)
+			
+			// 初期状態が公開以外で公開状態に設定したい場合は一度公開状態にする
+			if tt.initialStatus == valueobject.StatusPrivate && post.Status != valueobject.StatusPrivate {
+				post.SetStatus(valueobject.StatusPublished)
+				post.SetStatus(valueobject.StatusPrivate)
+			}
+			if tt.initialStatus == valueobject.StatusDeleted && post.Status != valueobject.StatusDeleted {
+				post.SetStatus(valueobject.StatusDeleted)
+			}
+
+			err := post.SetStatus(tt.targetStatus)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("エラーが期待されましたが、エラーが発生しませんでした")
+					return
+				}
+				if err.Error() != tt.expectedErr {
+					t.Errorf("期待されたエラーメッセージ = %v, 実際のエラーメッセージ = %v", tt.expectedErr, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("予期しないエラー: %v", err)
+				return
+			}
+
+			if !post.Status.Equals(tt.targetStatus) {
+				t.Errorf("Status = %v, want %v", post.Status, tt.targetStatus)
+			}
+		})
+	}
+}
+
+func TestParsePost(t *testing.T) {
+	id, _ := valueobject.ParsePostID("550e8400-e29b-41d4-a716-446655440000")
+	title, _ := valueobject.NewPostTitle("テストタイトル")
+	content, _ := valueobject.NewPostContent("テストコンテンツ")
+	userID := valueobject.NewUserID()
+	status := valueobject.StatusPublished
+	createdAt := time.Now().Add(-24 * time.Hour)
+	updatedAt := time.Now()
+	firstPublishedAt := time.Now().Add(-12 * time.Hour)
+	contentUpdatedAt := time.Now().Add(-6 * time.Hour)
+	tag1, _ := valueobject.NewTagName("golang")
+	tag2, _ := valueobject.NewTagName("testing")
+	tags := []valueobject.TagName{tag1, tag2}
+
+	post := ParsePost(
+		id,
+		title,
+		content,
+		userID,
+		status,
+		createdAt,
+		updatedAt,
+		&firstPublishedAt,
+		&contentUpdatedAt,
+		tags,
+	)
+
+	if post == nil {
+		t.Fatal("投稿がnilです")
+	}
+
+	// 各フィールドの検証
+	if !post.ID.Equals(id) {
+		t.Errorf("ID = %v, want %v", post.ID, id)
+	}
+
+	if !post.Title.Equals(title) {
+		t.Errorf("Title = %v, want %v", post.Title, title)
+	}
+
+	if !post.Content.Equals(content) {
+		t.Errorf("Content = %v, want %v", post.Content, content)
+	}
+
+	if !post.UserID.Equals(userID) {
+		t.Errorf("UserID = %v, want %v", post.UserID, userID)
+	}
+
+	if !post.Status.Equals(status) {
+		t.Errorf("Status = %v, want %v", post.Status, status)
+	}
+
+	if !post.CreatedAt.Equal(createdAt) {
+		t.Errorf("CreatedAt = %v, want %v", post.CreatedAt, createdAt)
+	}
+
+	if !post.UpdatedAt.Equal(updatedAt) {
+		t.Errorf("UpdatedAt = %v, want %v", post.UpdatedAt, updatedAt)
+	}
+
+	if len(post.Tags) != 2 {
+		t.Errorf("Tags length = %v, want %v", len(post.Tags), 2)
+	}
+}

--- a/src/internal/domain/entity/tag_test.go
+++ b/src/internal/domain/entity/tag_test.go
@@ -1,0 +1,146 @@
+package entity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MizukiShigi/cms-go/internal/domain/valueobject"
+)
+
+func TestNewTagWithName(t *testing.T) {
+	tagName, err := valueobject.NewTagName("golang")
+	if err != nil {
+		t.Fatalf("タグ名作成に失敗: %v", err)
+	}
+
+	tag := NewTagWithName(tagName)
+
+	if tag == nil {
+		t.Fatal("タグがnilです")
+	}
+
+	// フィールドの検証
+	if !tag.Name.Equals(tagName) {
+		t.Errorf("Name = %v, want %v", tag.Name, tagName)
+	}
+
+	// タイムスタンプが設定されていることを確認
+	if tag.CreatedAt.IsZero() {
+		t.Error("CreatedAtが設定されていません")
+	}
+
+	if tag.UpdatedAt.IsZero() {
+		t.Error("UpdatedAtが設定されていません")
+	}
+
+	// CreatedAtとUpdatedAtが同じ時刻であることを確認（新規作成のため）
+	if !tag.CreatedAt.Equal(tag.UpdatedAt) {
+		t.Error("新規作成時はCreatedAtとUpdatedAtが同じ時刻である必要があります")
+	}
+}
+
+func TestParseTag(t *testing.T) {
+	tagID := valueobject.NewTagID()
+
+	tagName, err := valueobject.NewTagName("testing")
+	if err != nil {
+		t.Fatalf("タグ名作成に失敗: %v", err)
+	}
+
+	createdAt := time.Now().Add(-24 * time.Hour)
+	updatedAt := time.Now()
+
+	tag := ParseTag(tagID, tagName, createdAt, updatedAt)
+
+	if tag == nil {
+		t.Fatal("タグがnilです")
+	}
+
+	// 各フィールドの検証
+	if !tag.ID.Equals(tagID) {
+		t.Errorf("ID = %v, want %v", tag.ID, tagID)
+	}
+
+	if !tag.Name.Equals(tagName) {
+		t.Errorf("Name = %v, want %v", tag.Name, tagName)
+	}
+
+	if !tag.CreatedAt.Equal(createdAt) {
+		t.Errorf("CreatedAt = %v, want %v", tag.CreatedAt, createdAt)
+	}
+
+	if !tag.UpdatedAt.Equal(updatedAt) {
+		t.Errorf("UpdatedAt = %v, want %v", tag.UpdatedAt, updatedAt)
+	}
+}
+
+func TestTag_FieldValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		tagName     string
+		wantErr     bool
+		expectedErr string
+	}{
+		{
+			name:    "正常ケース: 有効なタグ名",
+			tagName: "golang",
+			wantErr: false,
+		},
+		{
+			name:    "正常ケース: 数字を含むタグ名",
+			tagName: "go1-19",
+			wantErr: false,
+		},
+		{
+			name:    "正常ケース: アンダースコアを含むタグ名",
+			tagName: "web_development",
+			wantErr: false,
+		},
+		{
+			name:        "異常ケース: 大文字を含むタグ名",
+			tagName:     "GoLang",
+			wantErr:     true,
+			expectedErr: "TagName can only contain lowercase letters, numbers, hyphens, and underscores",
+		},
+		{
+			name:        "異常ケース: 長すぎるタグ名",
+			tagName:     "this-is-a-very-long-tag-name-that-exceeds-the-maximum-allowed-length",
+			wantErr:     true,
+			expectedErr: "TagName is too long",
+		},
+		{
+			name:        "異常ケース: 特殊文字を含むタグ名",
+			tagName:     "go@lang",
+			wantErr:     true,
+			expectedErr: "TagName can only contain lowercase letters, numbers, hyphens, and underscores",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tagName, err := valueobject.NewTagName(tt.tagName)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("エラーが期待されましたが、エラーが発生しませんでした")
+					return
+				}
+				if err.Error() != tt.expectedErr {
+					t.Errorf("期待されたエラーメッセージ = %v, 実際のエラーメッセージ = %v", tt.expectedErr, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("予期しないエラー: %v", err)
+				return
+			}
+
+			// タグエンティティの作成
+			tag := NewTagWithName(tagName)
+			if tag == nil {
+				t.Error("タグがnilです")
+			}
+		})
+	}
+}

--- a/src/internal/domain/entity/user_test.go
+++ b/src/internal/domain/entity/user_test.go
@@ -1,0 +1,155 @@
+package entity
+
+import (
+	"testing"
+
+	"github.com/MizukiShigi/cms-go/internal/domain/valueobject"
+)
+
+func TestNewUser(t *testing.T) {
+	tests := []struct {
+		name        string
+		userName    string
+		email       string
+		password    string
+		wantErr     bool
+		expectedErr string
+	}{
+		{
+			name:     "正常ケース: 有効なユーザー作成",
+			userName: "testuser",
+			email:    "test@example.com",
+			password: "password123",
+			wantErr:  false,
+		},
+		{
+			name:        "異常ケース: 空の名前",
+			userName:    "",
+			email:       "test@example.com",
+			password:    "password123",
+			wantErr:     true,
+			expectedErr: "Name cannot be empty",
+		},
+		{
+			name:        "異常ケース: 短いパスワード",
+			userName:    "testuser",
+			email:       "test@example.com",
+			password:    "1234567",
+			wantErr:     true,
+			expectedErr: "Password must be at least 8 characters",
+		},
+		{
+			name:        "異常ケース: 不正なメールアドレス",
+			userName:    "testuser",
+			email:       "invalid-email",
+			password:    "password123",
+			wantErr:     true,
+			expectedErr: "Invalid email format",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			email, emailErr := valueobject.NewEmail(tt.email)
+			if emailErr != nil && !tt.wantErr {
+				t.Errorf("メールアドレス作成でエラー: %v", emailErr)
+				return
+			}
+			if emailErr != nil && tt.wantErr && tt.expectedErr == "Invalid email format" {
+				// メールアドレス形式エラーの場合はここで期待通り
+				return
+			}
+
+			user, err := NewUser(tt.userName, email, tt.password)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("エラーが期待されましたが、エラーが発生しませんでした")
+					return
+				}
+				if err.Error() != tt.expectedErr {
+					t.Errorf("期待されたエラーメッセージ = %v, 実際のエラーメッセージ = %v", tt.expectedErr, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("予期しないエラー: %v", err)
+				return
+			}
+
+			if user == nil {
+				t.Error("ユーザーがnilです")
+				return
+			}
+
+			// フィールドの検証
+			if user.Name != tt.userName {
+				t.Errorf("Name = %v, want %v", user.Name, tt.userName)
+			}
+
+			if user.Email.String() != tt.email {
+				t.Errorf("Email = %v, want %v", user.Email.String(), tt.email)
+			}
+
+			// パスワードがハッシュ化されていることを確認
+			if user.Password == tt.password {
+				t.Error("パスワードがハッシュ化されていません")
+			}
+
+			// IDが生成されていることを確認
+			if user.ID.String() == "" {
+				t.Error("ユーザーIDが生成されていません")
+			}
+
+			// タイムスタンプが設定されていることを確認
+			if user.CreatedAt.IsZero() {
+				t.Error("CreatedAtが設定されていません")
+			}
+
+			if user.UpdatedAt.IsZero() {
+				t.Error("UpdatedAtが設定されていません")
+			}
+		})
+	}
+}
+
+func TestUser_Authenticate(t *testing.T) {
+	email, _ := valueobject.NewEmail("test@example.com")
+	password := "password123"
+	user, err := NewUser("testuser", email, password)
+	if err != nil {
+		t.Fatalf("ユーザー作成に失敗: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		password string
+		want     bool
+	}{
+		{
+			name:     "正常ケース: 正しいパスワード",
+			password: "password123",
+			want:     true,
+		},
+		{
+			name:     "異常ケース: 間違ったパスワード",
+			password: "wrongpassword",
+			want:     false,
+		},
+		{
+			name:     "異常ケース: 空のパスワード",
+			password: "",
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := user.Authenticate(tt.password)
+			if got != tt.want {
+				t.Errorf("Authenticate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/src/internal/domain/valueobject/email_test.go
+++ b/src/internal/domain/valueobject/email_test.go
@@ -1,0 +1,141 @@
+package valueobject
+
+import (
+	"testing"
+)
+
+func TestNewEmail(t *testing.T) {
+	tests := []struct {
+		name        string
+		email       string
+		wantErr     bool
+		expectedErr string
+	}{
+		{
+			name:    "正常ケース: 有効なメールアドレス",
+			email:   "test@example.com",
+			wantErr: false,
+		},
+		{
+			name:    "正常ケース: サブドメインを含むメールアドレス",
+			email:   "user@mail.example.com",
+			wantErr: false,
+		},
+		{
+			name:    "正常ケース: 数字を含むメールアドレス",
+			email:   "user123@example123.com",
+			wantErr: false,
+		},
+		{
+			name:    "正常ケース: ハイフンを含むメールアドレス",
+			email:   "user-name@example-domain.com",
+			wantErr: false,
+		},
+		{
+			name:    "正常ケース: プラス記号を含むメールアドレス",
+			email:   "user+tag@example.com",
+			wantErr: false,
+		},
+		{
+			name:        "異常ケース: @マークなし",
+			email:       "testexample.com",
+			wantErr:     true,
+			expectedErr: "Invalid email format",
+		},
+		{
+			name:        "異常ケース: ドメインなし",
+			email:       "test@",
+			wantErr:     true,
+			expectedErr: "Invalid email format",
+		},
+		{
+			name:        "異常ケース: ローカル部なし",
+			email:       "@example.com",
+			wantErr:     true,
+			expectedErr: "Invalid email format",
+		},
+		{
+			name:        "異常ケース: 拡張子なし",
+			email:       "test@example",
+			wantErr:     true,
+			expectedErr: "Invalid email format",
+		},
+		{
+			name:        "異常ケース: 空文字",
+			email:       "",
+			wantErr:     true,
+			expectedErr: "Invalid email format",
+		},
+		{
+			name:        "異常ケース: スペースを含む",
+			email:       "test @example.com",
+			wantErr:     true,
+			expectedErr: "Invalid email format",
+		},
+		{
+			name:        "異常ケース: 短すぎる拡張子",
+			email:       "test@example.c",
+			wantErr:     true,
+			expectedErr: "Invalid email format",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			email, err := NewEmail(tt.email)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("エラーが期待されましたが、エラーが発生しませんでした")
+					return
+				}
+				if err.Error() != tt.expectedErr {
+					t.Errorf("期待されたエラーメッセージ = %v, 実際のエラーメッセージ = %v", tt.expectedErr, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("予期しないエラー: %v", err)
+				return
+			}
+
+			if email.String() != tt.email {
+				t.Errorf("Email.String() = %v, want %v", email.String(), tt.email)
+			}
+		})
+	}
+}
+
+func TestEmail_String(t *testing.T) {
+	email, err := NewEmail("test@example.com")
+	if err != nil {
+		t.Fatalf("メールアドレス作成に失敗: %v", err)
+	}
+
+	expected := "test@example.com"
+	if email.String() != expected {
+		t.Errorf("String() = %v, want %v", email.String(), expected)
+	}
+}
+
+func TestEmail_Equals(t *testing.T) {
+	email1, _ := NewEmail("test@example.com")
+	email2, _ := NewEmail("test@example.com")
+	email3, _ := NewEmail("different@example.com")
+
+	// 同じメールアドレス
+	if !email1.Equals(email2) {
+		t.Error("同じメールアドレス同士の比較がfalseになりました")
+	}
+
+	// 異なるメールアドレス
+	if email1.Equals(email3) {
+		t.Error("異なるメールアドレス同士の比較がtrueになりました")
+	}
+
+	// 自身との比較
+	if !email1.Equals(email1) {
+		t.Error("自身との比較がfalseになりました")
+	}
+}

--- a/src/internal/domain/valueobject/post_status_test.go
+++ b/src/internal/domain/valueobject/post_status_test.go
@@ -1,0 +1,176 @@
+package valueobject
+
+import (
+	"testing"
+)
+
+func TestNewPostStatus(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      string
+		wantErr     bool
+		expectedErr string
+		expected    PostStatus
+	}{
+		{
+			name:     "正常ケース: draft",
+			status:   "draft",
+			wantErr:  false,
+			expected: StatusDraft,
+		},
+		{
+			name:     "正常ケース: published",
+			status:   "published",
+			wantErr:  false,
+			expected: StatusPublished,
+		},
+		{
+			name:     "正常ケース: private",
+			status:   "private",
+			wantErr:  false,
+			expected: StatusPrivate,
+		},
+		{
+			name:     "正常ケース: deleted",
+			status:   "deleted",
+			wantErr:  false,
+			expected: StatusDeleted,
+		},
+		{
+			name:        "異常ケース: 無効なステータス",
+			status:      "invalid",
+			wantErr:     true,
+			expectedErr: "Invalid post status",
+		},
+		{
+			name:        "異常ケース: 空文字",
+			status:      "",
+			wantErr:     true,
+			expectedErr: "Invalid post status",
+		},
+		{
+			name:        "異常ケース: 大文字",
+			status:      "DRAFT",
+			wantErr:     true,
+			expectedErr: "Invalid post status",
+		},
+		{
+			name:        "異常ケース: 混合文字",
+			status:      "Draft",
+			wantErr:     true,
+			expectedErr: "Invalid post status",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			postStatus, err := NewPostStatus(tt.status)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("エラーが期待されましたが、エラーが発生しませんでした")
+					return
+				}
+				if err.Error() != tt.expectedErr {
+					t.Errorf("期待されたエラーメッセージ = %v, 実際のエラーメッセージ = %v", tt.expectedErr, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("予期しないエラー: %v", err)
+				return
+			}
+
+			if !postStatus.Equals(tt.expected) {
+				t.Errorf("NewPostStatus() = %v, want %v", postStatus, tt.expected)
+			}
+		})
+	}
+}
+
+func TestPostStatus_Constants(t *testing.T) {
+	// 定数の値を確認
+	tests := []struct {
+		name     string
+		constant PostStatus
+		expected string
+	}{
+		{
+			name:     "StatusDraft",
+			constant: StatusDraft,
+			expected: "draft",
+		},
+		{
+			name:     "StatusPublished",
+			constant: StatusPublished,
+			expected: "published",
+		},
+		{
+			name:     "StatusPrivate",
+			constant: StatusPrivate,
+			expected: "private",
+		},
+		{
+			name:     "StatusDeleted",
+			constant: StatusDeleted,
+			expected: "deleted",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.constant.String() != tt.expected {
+				t.Errorf("%s.String() = %v, want %v", tt.name, tt.constant.String(), tt.expected)
+			}
+		})
+	}
+}
+
+func TestPostStatus_String(t *testing.T) {
+	status := StatusPublished
+	expected := "published"
+
+	if status.String() != expected {
+		t.Errorf("String() = %v, want %v", status.String(), expected)
+	}
+}
+
+func TestPostStatus_Equals(t *testing.T) {
+	status1 := StatusDraft
+	status2 := StatusDraft
+	status3 := StatusPublished
+
+	// 同じステータス
+	if !status1.Equals(status2) {
+		t.Error("同じステータス同士の比較がfalseになりました")
+	}
+
+	// 異なるステータス
+	if status1.Equals(status3) {
+		t.Error("異なるステータス同士の比較がtrueになりました")
+	}
+
+	// 自身との比較
+	if !status1.Equals(status1) {
+		t.Error("自身との比較がfalseになりました")
+	}
+}
+
+func TestPostStatus_AllValues(t *testing.T) {
+	// 全てのステータス値に対してNewPostStatusが正常に動作することを確認
+	statuses := []string{"draft", "published", "private", "deleted"}
+
+	for _, status := range statuses {
+		t.Run("status_"+status, func(t *testing.T) {
+			postStatus, err := NewPostStatus(status)
+			if err != nil {
+				t.Errorf("有効なステータス '%s' でエラーが発生しました: %v", status, err)
+			}
+
+			if postStatus.String() != status {
+				t.Errorf("String() = %v, want %v", postStatus.String(), status)
+			}
+		})
+	}
+}

--- a/src/internal/domain/valueobject/user_id_test.go
+++ b/src/internal/domain/valueobject/user_id_test.go
@@ -1,0 +1,158 @@
+package valueobject
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestNewUserID(t *testing.T) {
+	userID := NewUserID()
+
+	// 空でないことを確認
+	if userID.String() == "" {
+		t.Error("UserIDが空文字です")
+	}
+
+	// UUID形式であることを確認
+	_, err := uuid.Parse(userID.String())
+	if err != nil {
+		t.Errorf("UserIDが有効なUUID形式ではありません: %v", err)
+	}
+
+	// 2回連続で生成した際に異なる値であることを確認
+	userID2 := NewUserID()
+	if userID.Equals(userID2) {
+		t.Error("2回連続で生成したUserIDが同じ値になりました")
+	}
+}
+
+func TestParseUserID(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantErr     bool
+		expectedErr string
+	}{
+		{
+			name:    "正常ケース: 有効なUUID",
+			input:   "550e8400-e29b-41d4-a716-446655440000",
+			wantErr: false,
+		},
+		{
+			name:    "正常ケース: 別の有効なUUID",
+			input:   "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+			wantErr: false,
+		},
+		{
+			name:        "異常ケース: 無効なUUID形式",
+			input:       "invalid-uuid",
+			wantErr:     true,
+			expectedErr: "Invalid user ID",
+		},
+		{
+			name:        "異常ケース: 空文字",
+			input:       "",
+			wantErr:     true,
+			expectedErr: "Invalid user ID",
+		},
+		{
+			name:        "異常ケース: 短いUUID",
+			input:       "550e8400-e29b-41d4-a716",
+			wantErr:     true,
+			expectedErr: "Invalid user ID",
+		},
+		{
+			name:        "異常ケース: 長いUUID",
+			input:       "550e8400-e29b-41d4-a716-446655440000-extra",
+			wantErr:     true,
+			expectedErr: "Invalid user ID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			userID, err := ParseUserID(tt.input)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("エラーが期待されましたが、エラーが発生しませんでした")
+					return
+				}
+				if err.Error() != tt.expectedErr {
+					t.Errorf("期待されたエラーメッセージ = %v, 実際のエラーメッセージ = %v", tt.expectedErr, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("予期しないエラー: %v", err)
+				return
+			}
+
+			// 正規化されたUUID形式であることを確認
+			expectedNormalized := "550e8400-e29b-41d4-a716-446655440000"
+			if tt.input == "550e8400-e29b-41d4-a716-446655440000" && userID.String() != expectedNormalized {
+				t.Errorf("ParseUserID() = %v, want %v", userID.String(), expectedNormalized)
+			}
+		})
+	}
+}
+
+func TestUserID_String(t *testing.T) {
+	expectedUUID := "550e8400-e29b-41d4-a716-446655440000"
+	userID, err := ParseUserID(expectedUUID)
+	if err != nil {
+		t.Fatalf("UserID作成に失敗: %v", err)
+	}
+
+	if userID.String() != expectedUUID {
+		t.Errorf("String() = %v, want %v", userID.String(), expectedUUID)
+	}
+}
+
+func TestUserID_Equals(t *testing.T) {
+	uuid1 := "550e8400-e29b-41d4-a716-446655440000"
+	uuid2 := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+
+	userID1, _ := ParseUserID(uuid1)
+	userID2, _ := ParseUserID(uuid1) // 同じUUID
+	userID3, _ := ParseUserID(uuid2) // 異なるUUID
+
+	// 同じUUID
+	if !userID1.Equals(userID2) {
+		t.Error("同じUUID同士の比較がfalseになりました")
+	}
+
+	// 異なるUUID
+	if userID1.Equals(userID3) {
+		t.Error("異なるUUID同士の比較がtrueになりました")
+	}
+
+	// 自身との比較
+	if !userID1.Equals(userID1) {
+		t.Error("自身との比較がfalseになりました")
+	}
+}
+
+func TestUserID_Generation(t *testing.T) {
+	// 複数のUserIDを生成して重複がないことを確認
+	userIDs := make(map[string]bool)
+	const numTests = 100
+
+	for i := 0; i < numTests; i++ {
+		userID := NewUserID()
+		idStr := userID.String()
+
+		if userIDs[idStr] {
+			t.Errorf("重複したUserIDが生成されました: %s", idStr)
+		}
+		userIDs[idStr] = true
+
+		// 各IDがUUID形式であることを確認
+		_, err := uuid.Parse(idStr)
+		if err != nil {
+			t.Errorf("生成されたUserIDが有効なUUID形式ではありません: %s, error: %v", idStr, err)
+		}
+	}
+}


### PR DESCRIPTION
Issue #4 に対応して、CLAUDE.mdに従って最重要なドメイン層のテストコードを作成しました。

## 変更内容
- エンティティテスト（User, Post, Tag）を実装
- 値オブジェクトテスト（Email, UserID, PostStatus）を実装
- ビジネスロジックの検証とバリデーション機能をカバー

## テスト戦略
CLAUDE.mdに従い、最重要なドメイン層から優先的に実装し、ビジネスロジックの中核となる部分をカバーしています。

Generated with [Claude Code](https://claude.ai/code)