### PR TITLE
feat: ドメインと値オブジェクトのテストコード追加

### DIFF
--- a/src/internal/domain/valueobject/error_test.go
+++ b/src/internal/domain/valueobject/error_test.go
@@ -1,0 +1,261 @@
+package valueobject
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+)
+
+func TestNewMyError(t *testing.T) {
+	tests := []struct {
+		name    string
+		code    Code
+		message string
+	}{
+		{
+			name:    "正常ケース: InvalidCodeでエラー作成",
+			code:    InvalidCode,
+			message: "無効なリクエスト",
+		},
+		{
+			name:    "正常ケース: InternalServerErrorCodeでエラー作成",
+			code:    InternalServerErrorCode,
+			message: "内部サーバーエラー",
+		},
+		{
+			name:    "正常ケース: UnauthorizedCodeでエラー作成",
+			code:    UnauthorizedCode,
+			message: "認証が必要です",
+		},
+		{
+			name:    "正常ケース: ForbiddenCodeでエラー作成",
+			code:    ForbiddenCode,
+			message: "アクセスが禁止されています",
+		},
+		{
+			name:    "正常ケース: NotFoundCodeでエラー作成",
+			code:    NotFoundCode,
+			message: "リソースが見つかりません",
+		},
+		{
+			name:    "正常ケース: ConflictCodeでエラー作成",
+			code:    ConflictCode,
+			message: "競合が発生しました",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := NewMyError(tt.code, tt.message)
+
+			if err.Code != tt.code {
+				t.Errorf("Code = %v, want %v", err.Code, tt.code)
+			}
+			if err.Message != tt.message {
+				t.Errorf("Message = %v, want %v", err.Message, tt.message)
+			}
+		})
+	}
+}
+
+func TestMyError_Error(t *testing.T) {
+	message := "テストエラーメッセージ"
+	err := NewMyError(InvalidCode, message)
+
+	if err.Error() != message {
+		t.Errorf("Error() = %v, want %v", err.Error(), message)
+	}
+}
+
+func TestMyError_StatusCode(t *testing.T) {
+	tests := []struct {
+		name           string
+		code           Code
+		expectedStatus int
+	}{
+		{
+			name:           "InvalidCode",
+			code:           InvalidCode,
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:           "InternalServerErrorCode",
+			code:           InternalServerErrorCode,
+			expectedStatus: http.StatusInternalServerError,
+		},
+		{
+			name:           "UnauthorizedCode",
+			code:           UnauthorizedCode,
+			expectedStatus: http.StatusUnauthorized,
+		},
+		{
+			name:           "ForbiddenCode",
+			code:           ForbiddenCode,
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			name:           "NotFoundCode",
+			code:           NotFoundCode,
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			name:           "ConflictCode",
+			code:           ConflictCode,
+			expectedStatus: http.StatusConflict,
+		},
+		{
+			name:           "未知のコード",
+			code:           Code("UNKNOWN"),
+			expectedStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := NewMyError(tt.code, "テストメッセージ")
+			status := err.StatusCode()
+
+			if status != tt.expectedStatus {
+				t.Errorf("StatusCode() = %v, want %v", status, tt.expectedStatus)
+			}
+		})
+	}
+}
+
+func TestIsMyError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "正常ケース: MyErrorの場合",
+			err:      NewMyError(InvalidCode, "テストエラー"),
+			expected: true,
+		},
+		{
+			name:     "正常ケース: 標準エラーの場合",
+			err:      errors.New("標準エラー"),
+			expected: false,
+		},
+		{
+			name:     "正常ケース: nilエラーの場合",
+			err:      nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsMyError(tt.err)
+
+			if result != tt.expected {
+				t.Errorf("IsMyError() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestReturnMyError(t *testing.T) {
+	defaultErr := NewMyError(InternalServerErrorCode, "デフォルトエラー")
+	domainErr := NewMyError(InvalidCode, "ドメインエラー")
+
+	tests := []struct {
+		name     string
+		err      error
+		myerr    *MyError
+		expected *MyError
+	}{
+		{
+			name:     "正常ケース: MyErrorが渡された場合はそれを返す",
+			err:      domainErr,
+			myerr:    defaultErr,
+			expected: domainErr,
+		},
+		{
+			name:     "正常ケース: 標準エラーが渡された場合はdefaultを返す",
+			err:      errors.New("標準エラー"),
+			myerr:    defaultErr,
+			expected: defaultErr,
+		},
+		{
+			name:     "正常ケース: nilが渡された場合はdefaultを返す",
+			err:      nil,
+			myerr:    defaultErr,
+			expected: defaultErr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ReturnMyError(tt.err, tt.myerr)
+
+			if result.Code != tt.expected.Code {
+				t.Errorf("ReturnMyError().Code = %v, want %v", result.Code, tt.expected.Code)
+			}
+			if result.Message != tt.expected.Message {
+				t.Errorf("ReturnMyError().Message = %v, want %v", result.Message, tt.expected.Message)
+			}
+		})
+	}
+}
+
+func TestPredefinedErrors(t *testing.T) {
+	tests := []struct {
+		name          string
+		err           *MyError
+		expectedCode  Code
+		expectedMsg   string
+		expectedHTTP  int
+	}{
+		{
+			name:         "InvalidRequestError",
+			err:          InvalidRequestError,
+			expectedCode: InvalidCode,
+			expectedMsg:  "Invalid request",
+			expectedHTTP: http.StatusBadRequest,
+		},
+		{
+			name:         "InternalServerError",
+			err:          InternalServerError,
+			expectedCode: InternalServerErrorCode,
+			expectedMsg:  "Internal server error",
+			expectedHTTP: http.StatusInternalServerError,
+		},
+		{
+			name:         "ForbiddenError",
+			err:          ForbiddenError,
+			expectedCode: ForbiddenCode,
+			expectedMsg:  "Forbidden",
+			expectedHTTP: http.StatusForbidden,
+		},
+		{
+			name:         "NotFoundError",
+			err:          NotFoundError,
+			expectedCode: NotFoundCode,
+			expectedMsg:  "Not found",
+			expectedHTTP: http.StatusNotFound,
+		},
+		{
+			name:         "ConflictError",
+			err:          ConflictError,
+			expectedCode: ConflictCode,
+			expectedMsg:  "Conflict",
+			expectedHTTP: http.StatusConflict,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.err.Code != tt.expectedCode {
+				t.Errorf("Code = %v, want %v", tt.err.Code, tt.expectedCode)
+			}
+			if tt.err.Message != tt.expectedMsg {
+				t.Errorf("Message = %v, want %v", tt.err.Message, tt.expectedMsg)
+			}
+			if tt.err.StatusCode() != tt.expectedHTTP {
+				t.Errorf("StatusCode() = %v, want %v", tt.err.StatusCode(), tt.expectedHTTP)
+			}
+		})
+	}
+}

--- a/src/internal/domain/valueobject/post_content_test.go
+++ b/src/internal/domain/valueobject/post_content_test.go
@@ -1,0 +1,164 @@
+package valueobject
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewPostContent(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		wantErr     bool
+		expectedErr string
+	}{
+		{
+			name:    "正常ケース: 空のコンテンツ",
+			content: "",
+			wantErr: false,
+		},
+		{
+			name:    "正常ケース: 短いコンテンツ",
+			content: "これはテストコンテンツです。",
+			wantErr: false,
+		},
+		{
+			name:    "正常ケース: 通常の長さのコンテンツ",
+			content: strings.Repeat("テスト", 100),
+			wantErr: false,
+		},
+		{
+			name:    "正常ケース: 最大長のコンテンツ（10000文字）",
+			content: strings.Repeat("a", 10000),
+			wantErr: false,
+		},
+		{
+			name:    "正常ケース: 改行を含むコンテンツ",
+			content: "第1行目\n第2行目\n第3行目",
+			wantErr: false,
+		},
+		{
+			name:    "正常ケース: 特殊文字を含むコンテンツ",
+			content: "特殊文字：!@#$%^&*()_+-=[]{}|;':\",./<>?",
+			wantErr: false,
+		},
+		{
+			name:    "正常ケース: Unicode文字を含むコンテンツ",
+			content: "絵文字：😀😃😄😁😆😅🤣😂🙂🙃😉😊",
+			wantErr: false,
+		},
+		{
+			name:        "異常ケース: 長すぎるコンテンツ（10001文字）",
+			content:     strings.Repeat("a", 10001),
+			wantErr:     true,
+			expectedErr: "Content is too long",
+		},
+		{
+			name:        "異常ケース: 非常に長いコンテンツ",
+			content:     strings.Repeat("テスト", 5000),
+			wantErr:     true,
+			expectedErr: "Content is too long",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content, err := NewPostContent(tt.content)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("エラーが期待されましたが、エラーが発生しませんでした")
+					return
+				}
+				if err.Error() != tt.expectedErr {
+					t.Errorf("期待されたエラーメッセージ = %v, 実際のエラーメッセージ = %v", tt.expectedErr, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("予期しないエラー: %v", err)
+				return
+			}
+
+			if content.String() != tt.content {
+				t.Errorf("PostContent.String() = %v, want %v", content.String(), tt.content)
+			}
+		})
+	}
+}
+
+func TestPostContent_String(t *testing.T) {
+	content := "テストコンテンツ"
+	postContent, err := NewPostContent(content)
+	if err != nil {
+		t.Fatalf("PostContent作成に失敗: %v", err)
+	}
+
+	if postContent.String() != content {
+		t.Errorf("String() = %v, want %v", postContent.String(), content)
+	}
+}
+
+func TestPostContent_Equals(t *testing.T) {
+	content1, _ := NewPostContent("同じコンテンツ")
+	content2, _ := NewPostContent("同じコンテンツ")
+	content3, _ := NewPostContent("異なるコンテンツ")
+
+	// 同じコンテンツ
+	if !content1.Equals(content2) {
+		t.Error("同じコンテンツ同士の比較がfalseになりました")
+	}
+
+	// 異なるコンテンツ
+	if content1.Equals(content3) {
+		t.Error("異なるコンテンツ同士の比較がtrueになりました")
+	}
+
+	// 自身との比較
+	if !content1.Equals(content1) {
+		t.Error("自身との比較がfalseになりました")
+	}
+}
+
+func TestPostContent_Boundary(t *testing.T) {
+	// 境界値テスト：10000文字ちょうど
+	content10000 := strings.Repeat("a", 10000)
+	postContent, err := NewPostContent(content10000)
+	if err != nil {
+		t.Errorf("10000文字のコンテンツでエラーが発生しました: %v", err)
+	}
+	if len(postContent.String()) != 10000 {
+		t.Errorf("10000文字のコンテンツ長 = %d, want 10000", len(postContent.String()))
+	}
+
+	// 境界値テスト：10001文字
+	content10001 := strings.Repeat("a", 10001)
+	_, err = NewPostContent(content10001)
+	if err == nil {
+		t.Error("10001文字のコンテンツでエラーが発生しませんでした")
+	}
+}
+
+func TestPostContent_WithEmptyString(t *testing.T) {
+	// 空文字列の場合
+	postContent, err := NewPostContent("")
+	if err != nil {
+		t.Errorf("空文字列でエラーが発生しました: %v", err)
+	}
+	if postContent.String() != "" {
+		t.Errorf("空文字列の場合のString() = %v, want %v", postContent.String(), "")
+	}
+}
+
+func TestPostContent_WithWhitespace(t *testing.T) {
+	// 空白文字のみの場合
+	whitespaceContent := "   \n\t\r   "
+	postContent, err := NewPostContent(whitespaceContent)
+	if err != nil {
+		t.Errorf("空白文字でエラーが発生しました: %v", err)
+	}
+	if postContent.String() != whitespaceContent {
+		t.Errorf("空白文字の場合のString() = %v, want %v", postContent.String(), whitespaceContent)
+	}
+}

--- a/src/internal/domain/valueobject/post_id_test.go
+++ b/src/internal/domain/valueobject/post_id_test.go
@@ -1,0 +1,189 @@
+package valueobject
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestNewPostID(t *testing.T) {
+	postID := NewPostID()
+
+	// 空でないことを確認
+	if postID.String() == "" {
+		t.Error("PostIDが空文字です")
+	}
+
+	// UUID形式であることを確認
+	_, err := uuid.Parse(postID.String())
+	if err != nil {
+		t.Errorf("PostIDが有効なUUID形式ではありません: %v", err)
+	}
+
+	// 2回連続で生成した際に異なる値であることを確認
+	postID2 := NewPostID()
+	if postID.Equals(postID2) {
+		t.Error("2回連続で生成したPostIDが同じ値になりました")
+	}
+}
+
+func TestParsePostID(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantErr     bool
+		expectedErr string
+	}{
+		{
+			name:    "正常ケース: 有効なUUID",
+			input:   "550e8400-e29b-41d4-a716-446655440000",
+			wantErr: false,
+		},
+		{
+			name:    "正常ケース: 別の有効なUUID",
+			input:   "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+			wantErr: false,
+		},
+		{
+			name:    "正常ケース: ランダムに生成されたUUID",
+			input:   uuid.New().String(),
+			wantErr: false,
+		},
+		{
+			name:        "異常ケース: 無効なUUID形式",
+			input:       "invalid-uuid",
+			wantErr:     true,
+			expectedErr: "Invalid post ID",
+		},
+		{
+			name:        "異常ケース: 空文字",
+			input:       "",
+			wantErr:     true,
+			expectedErr: "Invalid post ID",
+		},
+		{
+			name:        "異常ケース: 短いUUID",
+			input:       "550e8400-e29b-41d4-a716",
+			wantErr:     true,
+			expectedErr: "Invalid post ID",
+		},
+		{
+			name:        "異常ケース: 長いUUID",
+			input:       "550e8400-e29b-41d4-a716-446655440000-extra",
+			wantErr:     true,
+			expectedErr: "Invalid post ID",
+		},
+		{
+			name:        "異常ケース: ハイフンなしのUUID",
+			input:       "550e8400e29b41d4a716446655440000",
+			wantErr:     true,
+			expectedErr: "Invalid post ID",
+		},
+		{
+			name:        "異常ケース: 大文字小文字混在（無効な文字）",
+			input:       "550e8400-e29b-41d4-a716-44665544000G",
+			wantErr:     true,
+			expectedErr: "Invalid post ID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			postID, err := ParsePostID(tt.input)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("エラーが期待されましたが、エラーが発生しませんでした")
+					return
+				}
+				if err.Error() != tt.expectedErr {
+					t.Errorf("期待されたエラーメッセージ = %v, 実際のエラーメッセージ = %v", tt.expectedErr, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("予期しないエラー: %v", err)
+				return
+			}
+
+			// 正規化されたUUID形式であることを確認
+			expectedNormalized := "550e8400-e29b-41d4-a716-446655440000"
+			if tt.input == "550e8400-e29b-41d4-a716-446655440000" && postID.String() != expectedNormalized {
+				t.Errorf("ParsePostID() = %v, want %v", postID.String(), expectedNormalized)
+			}
+		})
+	}
+}
+
+func TestPostID_String(t *testing.T) {
+	expectedUUID := "550e8400-e29b-41d4-a716-446655440000"
+	postID, err := ParsePostID(expectedUUID)
+	if err != nil {
+		t.Fatalf("PostID作成に失敗: %v", err)
+	}
+
+	if postID.String() != expectedUUID {
+		t.Errorf("String() = %v, want %v", postID.String(), expectedUUID)
+	}
+}
+
+func TestPostID_Equals(t *testing.T) {
+	uuid1 := "550e8400-e29b-41d4-a716-446655440000"
+	uuid2 := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+
+	postID1, _ := ParsePostID(uuid1)
+	postID2, _ := ParsePostID(uuid1) // 同じUUID
+	postID3, _ := ParsePostID(uuid2) // 異なるUUID
+
+	// 同じUUID
+	if !postID1.Equals(postID2) {
+		t.Error("同じUUID同士の比較がfalseになりました")
+	}
+
+	// 異なるUUID
+	if postID1.Equals(postID3) {
+		t.Error("異なるUUID同士の比較がtrueになりました")
+	}
+
+	// 自身との比較
+	if !postID1.Equals(postID1) {
+		t.Error("自身との比較がfalseになりました")
+	}
+}
+
+func TestPostID_Generation(t *testing.T) {
+	// 複数のPostIDを生成して重複がないことを確認
+	postIDs := make(map[string]bool)
+	const numTests = 100
+
+	for i := 0; i < numTests; i++ {
+		postID := NewPostID()
+		idStr := postID.String()
+
+		if postIDs[idStr] {
+			t.Errorf("重複したPostIDが生成されました: %s", idStr)
+		}
+		postIDs[idStr] = true
+
+		// 各IDがUUID形式であることを確認
+		_, err := uuid.Parse(idStr)
+		if err != nil {
+			t.Errorf("生成されたPostIDが有効なUUID形式ではありません: %s, error: %v", idStr, err)
+		}
+	}
+}
+
+func TestPostID_ParseAndEquals(t *testing.T) {
+	// 生成されたPostIDをパースして同一性を確認
+	originalID := NewPostID()
+	parsedID, err := ParsePostID(originalID.String())
+
+	if err != nil {
+		t.Errorf("生成されたPostIDのパースに失敗: %v", err)
+	}
+
+	if !originalID.Equals(parsedID) {
+		t.Error("生成されたPostIDとパースされたPostIDが一致しません")
+	}
+}

--- a/src/internal/domain/valueobject/post_title_test.go
+++ b/src/internal/domain/valueobject/post_title_test.go
@@ -1,0 +1,266 @@
+package valueobject
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewPostTitle(t *testing.T) {
+	tests := []struct {
+		name        string
+		title       string
+		wantErr     bool
+		expectedErr string
+	}{
+		{
+			name:    "正常ケース: 通常のタイトル",
+			title:   "これは通常のタイトルです",
+			wantErr: false,
+		},
+		{
+			name:    "正常ケース: 空のタイトル",
+			title:   "",
+			wantErr: false,
+		},
+		{
+			name:    "正常ケース: 前後に空白があるタイトル",
+			title:   "  タイトル  ",
+			wantErr: false,
+		},
+		{
+			name:    "正常ケース: 数字を含むタイトル",
+			title:   "記事No.123",
+			wantErr: false,
+		},
+		{
+			name:    "正常ケース: 最大長のタイトル（200文字）",
+			title:   strings.Repeat("あ", 200),
+			wantErr: false,
+		},
+		{
+			name:    "正常ケース: 英数字のタイトル",
+			title:   "My Blog Post 2023",
+			wantErr: false,
+		},
+		{
+			name:    "正常ケース: 特殊文字を含むタイトル（許可されたもの）",
+			title:   "ブログ記事：重要なお知らせ！",
+			wantErr: false,
+		},
+		{
+			name:        "異常ケース: 長すぎるタイトル（201文字）",
+			title:       strings.Repeat("あ", 201),
+			wantErr:     true,
+			expectedErr: "Title is too long",
+		},
+		{
+			name:        "異常ケース: 非常に長いタイトル",
+			title:       strings.Repeat("テスト", 100),
+			wantErr:     true,
+			expectedErr: "Title is too long",
+		},
+		{
+			name:        "異常ケース: 改行文字を含む",
+			title:       "タイトル\n改行",
+			wantErr:     true,
+			expectedErr: "Title contains forbidden character: '\\n'",
+		},
+		{
+			name:        "異常ケース: タブ文字を含む",
+			title:       "タイトル\tタブ",
+			wantErr:     true,
+			expectedErr: "Title contains forbidden character: '\\t'",
+		},
+		{
+			name:        "異常ケース: キャリッジリターンを含む",
+			title:       "タイトル\r復帰",
+			wantErr:     true,
+			expectedErr: "Title contains forbidden character: '\\r'",
+		},
+		{
+			name:        "異常ケース: HTMLタグを含む",
+			title:       "タイトル<script>alert('xss')</script>",
+			wantErr:     true,
+			expectedErr: "Title contains forbidden character: '<'",
+		},
+		{
+			name:        "異常ケース: 引用符を含む",
+			title:       "タイトル\"引用符",
+			wantErr:     true,
+			expectedErr: "Title contains forbidden character: '\"'",
+		},
+		{
+			name:        "異常ケース: 単一引用符を含む",
+			title:       "タイトル'単一引用符",
+			wantErr:     true,
+			expectedErr: "Title contains forbidden character: '\\''",
+		},
+		{
+			name:        "異常ケース: バックスラッシュを含む",
+			title:       "タイトル\\バックスラッシュ",
+			wantErr:     true,
+			expectedErr: "Title contains forbidden character: '\\\\'",
+		},
+		{
+			name:        "異常ケース: スラッシュを含む",
+			title:       "タイトル/スラッシュ",
+			wantErr:     true,
+			expectedErr: "Title contains forbidden character: '/'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			title, err := NewPostTitle(tt.title)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("エラーが期待されましたが、エラーが発生しませんでした")
+					return
+				}
+				if err.Error() != tt.expectedErr {
+					t.Errorf("期待されたエラーメッセージ = %v, 実際のエラーメッセージ = %v", tt.expectedErr, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("予期しないエラー: %v", err)
+				return
+			}
+
+			// 前後の空白が削除されていることを確認
+			expectedTitle := strings.TrimSpace(tt.title)
+			if title.Value() != expectedTitle {
+				t.Errorf("PostTitle.Value() = %v, want %v", title.Value(), expectedTitle)
+			}
+		})
+	}
+}
+
+func TestPostTitle_Value(t *testing.T) {
+	title := "テストタイトル"
+	postTitle, err := NewPostTitle(title)
+	if err != nil {
+		t.Fatalf("PostTitle作成に失敗: %v", err)
+	}
+
+	if postTitle.Value() != title {
+		t.Errorf("Value() = %v, want %v", postTitle.Value(), title)
+	}
+}
+
+func TestPostTitle_String(t *testing.T) {
+	title := "テストタイトル"
+	postTitle, err := NewPostTitle(title)
+	if err != nil {
+		t.Fatalf("PostTitle作成に失敗: %v", err)
+	}
+
+	// HTMLエスケープされた形で格納されている
+	if postTitle.String() == "" {
+		t.Error("String()が空文字を返しました")
+	}
+}
+
+func TestPostTitle_Equals(t *testing.T) {
+	title1, _ := NewPostTitle("同じタイトル")
+	title2, _ := NewPostTitle("同じタイトル")
+	title3, _ := NewPostTitle("異なるタイトル")
+
+	// 同じタイトル
+	if !title1.Equals(title2) {
+		t.Error("同じタイトル同士の比較がfalseになりました")
+	}
+
+	// 異なるタイトル
+	if title1.Equals(title3) {
+		t.Error("異なるタイトル同士の比較がtrueになりました")
+	}
+
+	// 自身との比較
+	if !title1.Equals(title1) {
+		t.Error("自身との比較がfalseになりました")
+	}
+}
+
+func TestPostTitle_TrimWhitespace(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "前後に空白がある場合",
+			input:    "  タイトル  ",
+			expected: "タイトル",
+		},
+		{
+			name:     "前に空白がある場合",
+			input:    "  タイトル",
+			expected: "タイトル",
+		},
+		{
+			name:     "後に空白がある場合",
+			input:    "タイトル  ",
+			expected: "タイトル",
+		},
+		{
+			name:     "空白なしの場合",
+			input:    "タイトル",
+			expected: "タイトル",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			title, err := NewPostTitle(tt.input)
+			if err != nil {
+				t.Errorf("予期しないエラー: %v", err)
+				return
+			}
+
+			if title.Value() != tt.expected {
+				t.Errorf("Value() = %v, want %v", title.Value(), tt.expected)
+			}
+		})
+	}
+}
+
+func TestPostTitle_Boundary(t *testing.T) {
+	// 境界値テスト：200文字ちょうど
+	title200 := strings.Repeat("あ", 200)
+	postTitle, err := NewPostTitle(title200)
+	if err != nil {
+		t.Errorf("200文字のタイトルでエラーが発生しました: %v", err)
+	}
+	if len(postTitle.Value()) != 200 {
+		t.Errorf("200文字のタイトル長 = %d, want 200", len(postTitle.Value()))
+	}
+
+	// 境界値テスト：201文字
+	title201 := strings.Repeat("あ", 201)
+	_, err = NewPostTitle(title201)
+	if err == nil {
+		t.Error("201文字のタイトルでエラーが発生しませんでした")
+	}
+}
+
+func TestPostTitle_HTMLEscaping(t *testing.T) {
+	// HTMLエスケープのテスト
+	title := "Title & Content"
+	postTitle, err := NewPostTitle(title)
+	if err != nil {
+		t.Fatalf("PostTitle作成に失敗: %v", err)
+	}
+
+	// Value()は元の値を返す
+	if postTitle.Value() != title {
+		t.Errorf("Value() = %v, want %v", postTitle.Value(), title)
+	}
+
+	// String()はエスケープされた値を返す
+	if postTitle.String() == title {
+		t.Error("String()がエスケープされていません")
+	}
+}

--- a/src/internal/domain/valueobject/tag_id_test.go
+++ b/src/internal/domain/valueobject/tag_id_test.go
@@ -1,0 +1,210 @@
+package valueobject
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestNewTagID(t *testing.T) {
+	tagID := NewTagID()
+
+	// 空でないことを確認
+	if tagID.String() == "" {
+		t.Error("TagIDが空文字です")
+	}
+
+	// UUID形式であることを確認
+	_, err := uuid.Parse(tagID.String())
+	if err != nil {
+		t.Errorf("TagIDが有効なUUID形式ではありません: %v", err)
+	}
+
+	// 2回連続で生成した際に異なる値であることを確認
+	tagID2 := NewTagID()
+	if tagID.Equals(tagID2) {
+		t.Error("2回連続で生成したTagIDが同じ値になりました")
+	}
+}
+
+func TestParseTagID(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			name:    "正常ケース: 有効なUUID",
+			input:   "550e8400-e29b-41d4-a716-446655440000",
+			wantErr: false,
+		},
+		{
+			name:    "正常ケース: 別の有効なUUID",
+			input:   "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+			wantErr: false,
+		},
+		{
+			name:    "正常ケース: ランダムに生成されたUUID",
+			input:   uuid.New().String(),
+			wantErr: false,
+		},
+		{
+			name:    "異常ケース: 無効なUUID形式",
+			input:   "invalid-uuid",
+			wantErr: true,
+		},
+		{
+			name:    "異常ケース: 空文字",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "異常ケース: 短いUUID",
+			input:   "550e8400-e29b-41d4-a716",
+			wantErr: true,
+		},
+		{
+			name:    "異常ケース: 長いUUID",
+			input:   "550e8400-e29b-41d4-a716-446655440000-extra",
+			wantErr: true,
+		},
+		{
+			name:    "異常ケース: ハイフンなしのUUID",
+			input:   "550e8400e29b41d4a716446655440000",
+			wantErr: true,
+		},
+		{
+			name:    "異常ケース: 大文字小文字混在（無効な文字）",
+			input:   "550e8400-e29b-41d4-a716-44665544000G",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tagID, err := ParseTagID(tt.input)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("エラーが期待されましたが、エラーが発生しませんでした")
+					return
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("予期しないエラー: %v", err)
+				return
+			}
+
+			// 正規化されたUUID形式であることを確認
+			expectedNormalized := "550e8400-e29b-41d4-a716-446655440000"
+			if tt.input == "550e8400-e29b-41d4-a716-446655440000" && tagID.String() != expectedNormalized {
+				t.Errorf("ParseTagID() = %v, want %v", tagID.String(), expectedNormalized)
+			}
+		})
+	}
+}
+
+func TestTagID_String(t *testing.T) {
+	expectedUUID := "550e8400-e29b-41d4-a716-446655440000"
+	tagID, err := ParseTagID(expectedUUID)
+	if err != nil {
+		t.Fatalf("TagID作成に失敗: %v", err)
+	}
+
+	if tagID.String() != expectedUUID {
+		t.Errorf("String() = %v, want %v", tagID.String(), expectedUUID)
+	}
+}
+
+func TestTagID_Equals(t *testing.T) {
+	uuid1 := "550e8400-e29b-41d4-a716-446655440000"
+	uuid2 := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+
+	tagID1, _ := ParseTagID(uuid1)
+	tagID2, _ := ParseTagID(uuid1) // 同じUUID
+	tagID3, _ := ParseTagID(uuid2) // 異なるUUID
+
+	// 同じUUID
+	if !tagID1.Equals(tagID2) {
+		t.Error("同じUUID同士の比較がfalseになりました")
+	}
+
+	// 異なるUUID
+	if tagID1.Equals(tagID3) {
+		t.Error("異なるUUID同士の比較がtrueになりました")
+	}
+
+	// 自身との比較
+	if !tagID1.Equals(tagID1) {
+		t.Error("自身との比較がfalseになりました")
+	}
+}
+
+func TestTagID_Generation(t *testing.T) {
+	// 複数のTagIDを生成して重複がないことを確認
+	tagIDs := make(map[string]bool)
+	const numTests = 100
+
+	for i := 0; i < numTests; i++ {
+		tagID := NewTagID()
+		idStr := tagID.String()
+
+		if tagIDs[idStr] {
+			t.Errorf("重複したTagIDが生成されました: %s", idStr)
+		}
+		tagIDs[idStr] = true
+
+		// 各IDがUUID形式であることを確認
+		_, err := uuid.Parse(idStr)
+		if err != nil {
+			t.Errorf("生成されたTagIDが有効なUUID形式ではありません: %s, error: %v", idStr, err)
+		}
+	}
+}
+
+func TestTagID_ParseAndEquals(t *testing.T) {
+	// 生成されたTagIDをパースして同一性を確認
+	originalID := NewTagID()
+	parsedID, err := ParseTagID(originalID.String())
+
+	if err != nil {
+		t.Errorf("生成されたTagIDのパースに失敗: %v", err)
+	}
+
+	if !originalID.Equals(parsedID) {
+		t.Error("生成されたTagIDとパースされたTagIDが一致しません")
+	}
+}
+
+func TestTagID_EmptyString(t *testing.T) {
+	// 空文字をパースした場合のテスト
+	_, err := ParseTagID("")
+	if err == nil {
+		t.Error("空文字のパースでエラーが発生しませんでした")
+	}
+}
+
+func TestTagID_ValidUUIDFormats(t *testing.T) {
+	// 様々な有効なUUID形式をテスト
+	validUUIDs := []string{
+		"00000000-0000-0000-0000-000000000000", // nil UUID
+		"123e4567-e89b-12d3-a456-426614174000", // version 1
+		"6ba7b810-9dad-11d1-80b4-00c04fd430c8", // version 1
+		"a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", // version 4
+		"87b3042c-cc7e-4b1a-9a47-0a3f5fd2e2ad", // version 4
+	}
+
+	for _, uuidStr := range validUUIDs {
+		t.Run("Valid UUID: "+uuidStr, func(t *testing.T) {
+			tagID, err := ParseTagID(uuidStr)
+			if err != nil {
+				t.Errorf("有効なUUID %s のパースに失敗: %v", uuidStr, err)
+			}
+			if tagID.String() != uuidStr {
+				t.Errorf("パース結果 = %v, want %v", tagID.String(), uuidStr)
+			}
+		})
+	}
+}

--- a/src/internal/domain/valueobject/tag_name_test.go
+++ b/src/internal/domain/valueobject/tag_name_test.go
@@ -1,0 +1,293 @@
+package valueobject
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewTagName(t *testing.T) {
+	tests := []struct {
+		name        string
+		tag         string
+		wantErr     bool
+		expectedErr string
+	}{
+		{
+			name:    "正常ケース: 小文字の英字のみ",
+			tag:     "technology",
+			wantErr: false,
+		},
+		{
+			name:    "正常ケース: 数字を含む",
+			tag:     "tech2023",
+			wantErr: false,
+		},
+		{
+			name:    "正常ケース: ハイフンを含む",
+			tag:     "web-development",
+			wantErr: false,
+		},
+		{
+			name:    "正常ケース: アンダースコアを含む",
+			tag:     "go_lang",
+			wantErr: false,
+		},
+		{
+			name:    "正常ケース: 大文字が小文字に変換される",
+			tag:     "JavaScript",
+			wantErr: false,
+		},
+		{
+			name:    "正常ケース: 前後に空白があるタグ",
+			tag:     "  programming  ",
+			wantErr: false,
+		},
+		{
+			name:    "正常ケース: 最大長のタグ（50文字）",
+			tag:     strings.Repeat("a", 50),
+			wantErr: false,
+		},
+		{
+			name:    "正常ケース: 数字のみ",
+			tag:     "2023",
+			wantErr: false,
+		},
+		{
+			name:    "正常ケース: ハイフンとアンダースコアの組み合わせ",
+			tag:     "web-dev_2023",
+			wantErr: false,
+		},
+		{
+			name:        "異常ケース: 長すぎるタグ（51文字）",
+			tag:         strings.Repeat("a", 51),
+			wantErr:     true,
+			expectedErr: "TagName is too long",
+		},
+		{
+			name:        "異常ケース: 非常に長いタグ",
+			tag:         strings.Repeat("tag", 25),
+			wantErr:     true,
+			expectedErr: "TagName is too long",
+		},
+		{
+			name:        "異常ケース: スペースを含む",
+			tag:         "web development",
+			wantErr:     true,
+			expectedErr: "TagName can only contain lowercase letters, numbers, hyphens, and underscores",
+		},
+		{
+			name:        "異常ケース: 特殊文字を含む",
+			tag:         "tech!",
+			wantErr:     true,
+			expectedErr: "TagName can only contain lowercase letters, numbers, hyphens, and underscores",
+		},
+		{
+			name:        "異常ケース: 日本語を含む",
+			tag:         "プログラミング",
+			wantErr:     true,
+			expectedErr: "TagName can only contain lowercase letters, numbers, hyphens, and underscores",
+		},
+		{
+			name:        "異常ケース: ドットを含む",
+			tag:         "node.js",
+			wantErr:     true,
+			expectedErr: "TagName can only contain lowercase letters, numbers, hyphens, and underscores",
+		},
+		{
+			name:        "異常ケース: カンマを含む",
+			tag:         "web,dev",
+			wantErr:     true,
+			expectedErr: "TagName can only contain lowercase letters, numbers, hyphens, and underscores",
+		},
+		{
+			name:        "異常ケース: アットマークを含む",
+			tag:         "@tag",
+			wantErr:     true,
+			expectedErr: "TagName can only contain lowercase letters, numbers, hyphens, and underscores",
+		},
+		{
+			name:        "異常ケース: スラッシュを含む",
+			tag:         "web/dev",
+			wantErr:     true,
+			expectedErr: "TagName can only contain lowercase letters, numbers, hyphens, and underscores",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tagName, err := NewTagName(tt.tag)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("エラーが期待されましたが、エラーが発生しませんでした")
+					return
+				}
+				if err.Error() != tt.expectedErr {
+					t.Errorf("期待されたエラーメッセージ = %v, 実際のエラーメッセージ = %v", tt.expectedErr, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("予期しないエラー: %v", err)
+				return
+			}
+
+			// 正規化された値が返されることを確認
+			expectedNormalized := strings.ToLower(strings.TrimSpace(tt.tag))
+			if tagName.String() != expectedNormalized {
+				t.Errorf("TagName.String() = %v, want %v", tagName.String(), expectedNormalized)
+			}
+		})
+	}
+}
+
+func TestTagName_String(t *testing.T) {
+	tag := "programming"
+	tagName, err := NewTagName(tag)
+	if err != nil {
+		t.Fatalf("TagName作成に失敗: %v", err)
+	}
+
+	if tagName.String() != tag {
+		t.Errorf("String() = %v, want %v", tagName.String(), tag)
+	}
+}
+
+func TestTagName_Equals(t *testing.T) {
+	tag1, _ := NewTagName("golang")
+	tag2, _ := NewTagName("golang")
+	tag3, _ := NewTagName("javascript")
+
+	// 同じタグ名
+	if !tag1.Equals(tag2) {
+		t.Error("同じタグ名同士の比較がfalseになりました")
+	}
+
+	// 異なるタグ名
+	if tag1.Equals(tag3) {
+		t.Error("異なるタグ名同士の比較がtrueになりました")
+	}
+
+	// 自身との比較
+	if !tag1.Equals(tag1) {
+		t.Error("自身との比較がfalseになりました")
+	}
+}
+
+func TestTagName_Normalization(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "大文字が小文字に変換される",
+			input:    "JavaScript",
+			expected: "javascript",
+		},
+		{
+			name:     "前後の空白が削除される",
+			input:    "  golang  ",
+			expected: "golang",
+		},
+		{
+			name:     "大文字と空白の組み合わせ",
+			input:    "  WEB-DEV  ",
+			expected: "web-dev",
+		},
+		{
+			name:     "すでに正規化されている場合",
+			input:    "python",
+			expected: "python",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tagName, err := NewTagName(tt.input)
+			if err != nil {
+				t.Errorf("予期しないエラー: %v", err)
+				return
+			}
+
+			if tagName.String() != tt.expected {
+				t.Errorf("String() = %v, want %v", tagName.String(), tt.expected)
+			}
+		})
+	}
+}
+
+func TestTagName_Boundary(t *testing.T) {
+	// 境界値テスト：50文字ちょうど
+	tag50 := strings.Repeat("a", 50)
+	tagName, err := NewTagName(tag50)
+	if err != nil {
+		t.Errorf("50文字のタグでエラーが発生しました: %v", err)
+	}
+	if len(tagName.String()) != 50 {
+		t.Errorf("50文字のタグ長 = %d, want 50", len(tagName.String()))
+	}
+
+	// 境界値テスト：51文字
+	tag51 := strings.Repeat("a", 51)
+	_, err = NewTagName(tag51)
+	if err == nil {
+		t.Error("51文字のタグでエラーが発生しませんでした")
+	}
+}
+
+func TestTagName_ValidCharacters(t *testing.T) {
+	validChars := []string{
+		"a", "z", "0", "9", "-", "_",
+		"abc123", "test-tag", "tag_name", "a1b2c3",
+	}
+
+	for _, char := range validChars {
+		t.Run("Valid: "+char, func(t *testing.T) {
+			_, err := NewTagName(char)
+			if err != nil {
+				t.Errorf("有効な文字列 %s でエラーが発生しました: %v", char, err)
+			}
+		})
+	}
+}
+
+func TestTagName_InvalidCharacters(t *testing.T) {
+	invalidChars := []string{
+		" ", "!", "@", "#", "$", "%", "^", "&", "*", "(", ")",
+		"+", "=", "[", "]", "{", "}", "|", "\\", ":", ";", "\"",
+		"'", "<", ">", ",", ".", "?", "/", "あ", "漢字",
+	}
+
+	for _, char := range invalidChars {
+		t.Run("Invalid: "+char, func(t *testing.T) {
+			_, err := NewTagName("test" + char + "tag")
+			if err == nil {
+				t.Errorf("無効な文字 %s を含むタグでエラーが発生しませんでした", char)
+			}
+		})
+	}
+}
+
+func TestTagName_EmptyString(t *testing.T) {
+	// 空文字列の場合（正規化後も空文字列）
+	tagName, err := NewTagName("")
+	if err != nil {
+		t.Errorf("空文字列でエラーが発生しました: %v", err)
+	}
+	if tagName.String() != "" {
+		t.Errorf("空文字列の場合のString() = %v, want %v", tagName.String(), "")
+	}
+}
+
+func TestTagName_OnlyWhitespace(t *testing.T) {
+	// 空白のみの場合（正規化後は空文字列）
+	tagName, err := NewTagName("   ")
+	if err != nil {
+		t.Errorf("空白のみでエラーが発生しました: %v", err)
+	}
+	if tagName.String() != "" {
+		t.Errorf("空白のみの場合のString() = %v, want %v", tagName.String(), "")
+	}
+}


### PR DESCRIPTION
issue #6 への対応として、ドメインと値オブジェクトの不足していたテストコードを6つ作成しました。

## 作成したテストファイル

- error_test.go - MyError構造体とエラーハンドリングのテスト
- post_content_test.go - 投稿コンテンツの検証ロジックのテスト
- post_id_test.go - UUID形式の投稿IDの生成とパースのテスト
- post_title_test.go - タイトルの正規化とHTMLエスケープのテスト
- tag_id_test.go - UUID形式のタグIDの生成とパースのテスト
- tag_name_test.go - タグ名の正規化と文字制限のテスト

Generated with [Claude Code](https://claude.ai/code)